### PR TITLE
Testfix

### DIFF
--- a/mqtt/listeners/http_sysinfo_test.go
+++ b/mqtt/listeners/http_sysinfo_test.go
@@ -77,7 +77,7 @@ func TestHTTPStatsServeAndClose(t *testing.T) {
 	time.Sleep(time.Millisecond)
 
 	// get body from stats address
-	resp, err := http.Get("http://localhost" + testAddr)
+	resp, err := http.Get("http://localhost" + testAddr + "/mqtt/stats")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 

--- a/mqtt/listeners/tcp_test.go
+++ b/mqtt/listeners/tcp_test.go
@@ -38,10 +38,11 @@ func TestTCPProtocolTLS(t *testing.T) {
 	l := NewTCP("t1", testAddr, &Config{
 		TLSConfig: tlsConfigBasic,
 	})
-
-	l.Init(&logger)
-	defer l.listen.Close()
+	err := l.Init(&logger)
+	require.NoError(t, err)
 	require.Equal(t, "tcp", l.Protocol())
+	err = l.listen.Close()
+	require.NoError(t, err)
 }
 
 func TestTCPInit(t *testing.T) {

--- a/mqtt/listeners/tcp_test.go
+++ b/mqtt/listeners/tcp_test.go
@@ -35,7 +35,8 @@ func TestTCPProtocol(t *testing.T) {
 }
 
 func TestTCPProtocolTLS(t *testing.T) {
-	l := NewTCP("t1", testAddr, &Config{
+	// pick a random port:
+	l := NewTCP("t1", ":0", &Config{
 		TLSConfig: tlsConfigBasic,
 	})
 	err := l.Init(&logger)
@@ -46,12 +47,12 @@ func TestTCPProtocolTLS(t *testing.T) {
 }
 
 func TestTCPInit(t *testing.T) {
-	l := NewTCP("t1", testAddr, nil)
+	l := NewTCP("t1", ":0", nil)
 	err := l.Init(&logger)
 	l.Close(MockCloser)
 	require.NoError(t, err)
 
-	l2 := NewTCP("t2", testAddr, &Config{
+	l2 := NewTCP("t2", ":0", &Config{
 		TLSConfig: tlsConfigBasic,
 	})
 	err = l2.Init(&logger)
@@ -61,7 +62,7 @@ func TestTCPInit(t *testing.T) {
 }
 
 func TestTCPServeAndClose(t *testing.T) {
-	l := NewTCP("t1", testAddr, nil)
+	l := NewTCP("t1", ":0", nil)
 	err := l.Init(&logger)
 	require.NoError(t, err)
 
@@ -86,7 +87,7 @@ func TestTCPServeAndClose(t *testing.T) {
 }
 
 func TestTCPServeTLSAndClose(t *testing.T) {
-	l := NewTCP("t1", testAddr, &Config{
+	l := NewTCP("t1", ":0", &Config{
 		TLSConfig: tlsConfigBasic,
 	})
 	err := l.Init(&logger)
@@ -110,7 +111,7 @@ func TestTCPServeTLSAndClose(t *testing.T) {
 }
 
 func TestTCPEstablishThenEnd(t *testing.T) {
-	l := NewTCP("t1", testAddr, nil)
+	l := NewTCP("t1", ":0", nil)
 	err := l.Init(&logger)
 	require.NoError(t, err)
 

--- a/mqtt/server_test.go
+++ b/mqtt/server_test.go
@@ -1685,7 +1685,8 @@ func TestPublishToSubscribersPkIgnore(t *testing.T) {
 		pk.Ignore = true
 		s.PublishToSubscribers(pk)
 		time.Sleep(time.Millisecond)
-		w.Close()
+		err := w.Close()
+		require.NoError(t, err)
 	}()
 
 	receiverBuf := make(chan []byte)

--- a/plugin/auth/http/http_test.go
+++ b/plugin/auth/http/http_test.go
@@ -96,31 +96,36 @@ func TestAuthenticateWithGet(t *testing.T) {
 func TestAclWithPost(t *testing.T) {
 	a := newAuth(t)
 	user := "zhangsan"
-	topic := "topictest/1"
+	topic1 := "topictest/1"
 	topic2 := "topictest/2"
+
+	payload := map[string]int{
+		topic1: 3,
+	}
+	body, _ := json.Marshal(payload)
 	defer gock.Off() // Flush pending mocks after test execution
 
 	//publish
 	gock.New("http://localhost:8080").
 		Post("/comqtt/acl").
-		JSON(map[string]string{"user": user, "topic": topic}).
-		Reply(200).BodyString("2")
-	result := a.OnACLCheck(client, topic, true)
+		JSON(map[string]string{"user": user}).
+		Reply(200).BodyString(string(body))
+	result := a.OnACLCheck(client, topic1, true)
 	require.Equal(t, true, result)
 
 	//subscribe
 	gock.New("http://localhost:8080").
 		Post("/comqtt/acl").
-		JSON(map[string]string{"user": user, "topic": topic}).
-		Reply(200).BodyString("1")
-	result = a.OnACLCheck(client, topic, false)
+		JSON(map[string]string{"user": user}).
+		Reply(200).BodyString(string(body))
+	result = a.OnACLCheck(client, topic1, false)
 	require.Equal(t, true, result)
 
 	//publish topic2, topic2 does not exist
 	gock.New("http://localhost:8080").
 		Post("/comqtt/acl").
-		JSON(map[string]string{"user": user, "topic": topic2}).
-		Reply(200).BodyString("0")
+		JSON(map[string]string{"user": user}).
+		Reply(200).BodyString(string(body))
 	result = a.OnACLCheck(client, topic2, true)
 	require.Equal(t, false, result)
 
@@ -128,24 +133,24 @@ func TestAclWithPost(t *testing.T) {
 	gock.New("http://localhost:8080").
 		Post("/comqtt/acl").
 		JSON(map[string]string{"user": user, "topic": topic2}).
-		Reply(200).BodyString("0")
+		Reply(200).BodyString(string(body))
 	result = a.OnACLCheck(client, topic2, false)
 	require.Equal(t, false, result)
 
 	//pubsub
 	gock.New("http://localhost:8080").
 		Post("/comqtt/acl").
-		JSON(map[string]string{"user": user, "topic": topic2}).
-		Reply(200).BodyString("3")
+		JSON(map[string]string{"user": user}).
+		Reply(200).BodyString(string(body))
 	result = a.OnACLCheck(client, topic2, true)
-	require.Equal(t, true, result)
+	require.Equal(t, false, result)
 
 	gock.New("http://localhost:8080").
 		Post("/comqtt/acl").
-		JSON(map[string]string{"user": user, "topic": topic2}).
-		Reply(200).BodyString("3")
+		JSON(map[string]string{"user": user}).
+		Reply(200).BodyString(string(body))
 	result = a.OnACLCheck(client, topic2, false)
-	require.Equal(t, true, result)
+	require.Equal(t, false, result)
 }
 
 func TestAclWithGet(t *testing.T) {

--- a/plugin/auth/mysql/mysql_test.go
+++ b/plugin/auth/mysql/mysql_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/wind-c/comqtt/v2/mqtt/hooks/auth"
 	"github.com/wind-c/comqtt/v2/mqtt/packets"
 	"github.com/wind-c/comqtt/v2/plugin"
+	"net"
 	"os"
 	"testing"
 )
@@ -73,6 +74,9 @@ func newAuth(t *testing.T) *Auth {
 }
 
 func TestInitFromConfFile(t *testing.T) {
+	if !hasMysql() {
+		t.SkipNow()
+	}
 	a := new(Auth)
 	a.SetOpts(&logger, nil)
 	opts := Options{}
@@ -92,6 +96,9 @@ func TestInitBadConfig(t *testing.T) {
 }
 
 func TestOnConnectAuthenticate(t *testing.T) {
+	if !hasMysql() {
+		t.SkipNow()
+	}
 	a := newAuth(t)
 	defer teardown(a, t)
 	result := a.OnConnectAuthenticate(client, pkc)
@@ -99,6 +106,9 @@ func TestOnConnectAuthenticate(t *testing.T) {
 }
 
 func TestOnACLCheck(t *testing.T) {
+	if !hasMysql() {
+		t.SkipNow()
+	}
 	a := newAuth(t)
 	defer teardown(a, t)
 	topic := "topictest/1"
@@ -111,4 +121,14 @@ func TestOnACLCheck(t *testing.T) {
 	require.Equal(t, false, result)
 	result = a.OnACLCheck(client, topic2, false)
 	require.Equal(t, false, result)
+}
+
+// hasMysql does a TCP connect to port 3306 to see if there is a MySQL server running on localhost.
+func hasMysql() bool {
+	c, err := net.Dial("tcp", "localhost:3306")
+	if err != nil {
+		return false
+	}
+	_ = c.Close()
+	return true
 }

--- a/plugin/auth/postgresql/postgresql_test.go
+++ b/plugin/auth/postgresql/postgresql_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/wind-c/comqtt/v2/mqtt/hooks/auth"
 	"github.com/wind-c/comqtt/v2/mqtt/packets"
 	"github.com/wind-c/comqtt/v2/plugin"
+	"net"
 	"os"
 	"testing"
 )
@@ -73,6 +74,9 @@ func newAuth(t *testing.T) *Auth {
 }
 
 func TestInitFromConfFile(t *testing.T) {
+	if !hasPostgresql() {
+		t.Skip("no postgresql server running")
+	}
 	a := new(Auth)
 	a.SetOpts(&logger, nil)
 	opts := Options{}
@@ -92,6 +96,9 @@ func TestInitBadConfig(t *testing.T) {
 }
 
 func TestOnConnectAuthenticate(t *testing.T) {
+	if !hasPostgresql() {
+		t.Skip("no postgresql server running")
+	}
 	a := newAuth(t)
 	defer teardown(a, t)
 	result := a.OnConnectAuthenticate(client, pkc)
@@ -99,6 +106,9 @@ func TestOnConnectAuthenticate(t *testing.T) {
 }
 
 func TestOnACLCheck(t *testing.T) {
+	if !hasPostgresql() {
+		t.Skip("no postgresql server running")
+	}
 	a := newAuth(t)
 	defer teardown(a, t)
 	topic := "topictest/1"
@@ -111,4 +121,14 @@ func TestOnACLCheck(t *testing.T) {
 	require.Equal(t, false, result)
 	result = a.OnACLCheck(client, topic2, false)
 	require.Equal(t, false, result)
+}
+
+// hasPostgresql does a TCP connect to port 3306 to see if there is a MySQL server running on localhost.
+func hasPostgresql() bool {
+	c, err := net.Dial("tcp", "localhost:5432")
+	if err != nil {
+		return false
+	}
+	_ = c.Close()
+	return true
 }


### PR DESCRIPTION
A few more fixed tests. As previously mention I skip most mysql and postgresql tests if the relevant sql server isn't running.

Also, I used ":0" as an address for some of the listener tests as I suspect Go test was running these tests in parallel and they where interfering with each other. Seems to work.