### PR TITLE
Remove recover() + fix grpc shutdown issue

### DIFF
--- a/cluster/agent.go
+++ b/cluster/agent.go
@@ -168,11 +168,6 @@ func (a *Agent) SubmitRaftTask(msg *message.Message) {
 }
 
 func (a *Agent) Stop() {
-	defer func() {
-		if err := recover(); err != nil {
-			zero.Error().Msg("not graceful stop")
-		}
-	}()
 	a.cancel()
 	a.OutPool.Release()
 	a.raftPool.Release()

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -79,6 +79,10 @@ func (s *RpcService) StartRpcServer() error {
 }
 
 func (s *RpcService) StopRpcServer() {
+	// if s or the grpc server is nil, return, there is nothing to stop.
+	if s == nil || s.grpcServer == nil {
+		return
+	}
 	s.grpcServer.GracefulStop()
 }
 

--- a/cmd/cluster/main.go
+++ b/cmd/cluster/main.go
@@ -40,6 +40,7 @@ var agent *cs.Agent
 var logger *zerolog.Logger
 
 func init() {
+	return
 	go func() {
 		log.Println(http.ListenAndServe(":6060", nil))
 	}()

--- a/cmd/cluster/main.go
+++ b/cmd/cluster/main.go
@@ -40,7 +40,6 @@ var agent *cs.Agent
 var logger *zerolog.Logger
 
 func init() {
-	return
 	go func() {
 		log.Println(http.ListenAndServe(":6060", nil))
 	}()

--- a/cmd/cluster/main_test.go
+++ b/cmd/cluster/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"go.uber.org/goleak"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -22,6 +23,8 @@ func TestLeaks(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		os.Args = []string{"binary", "-node-name", "testnode", "-members", "localhost:7946",
+			"-raft-bootstrap", "true", "-storage-way", "memory"}
 		err := realMain(ctx)
 		if err != nil {
 			panic("realMain error" + err.Error())
@@ -31,4 +34,5 @@ func TestLeaks(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 	cancel()
 	wg.Wait()
+	time.Sleep(time.Millisecond * 100)
 }


### PR DESCRIPTION
Here is an improvement for #60, it removes the unclean shutdown. The goleak verifier till fails, but I'll fix those eventually. :-)