### PR TITLE
Fix for the leak test

### DIFF
--- a/cmd/cluster/main.go
+++ b/cmd/cluster/main.go
@@ -39,6 +39,7 @@ import (
 var agent *cs.Agent
 var logger *zerolog.Logger
 
+// init for pprof:
 func init() {
 	go func() {
 		log.Println(http.ListenAndServe(":6060", nil))


### PR DESCRIPTION
I've got the leak test working. I've looked over the threads that were left. I see I could stop the event loop by closing the channel on shutdown. I assume the event loop will only be stopped once. 

I've also made a few other improvements along the way.

Cheers,

Per.