### PR TITLE
Upgrade builder image to golang:1.21-alpine3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.16 AS builder
+FROM golang:1.21-alpine3.20 AS builder
 
 RUN apk update
 RUN apk add git


### PR DESCRIPTION
Fix the following error:

```
Step 1/16 : FROM golang:1.20-alpine3.16 AS builder
1.20-alpine3.16: Pulling from library/golang
91d30c5bc195: Pulling fs layer
65d52c8ad3c4: Pulling fs layer
fd88c46576ef: Pulling fs layer
e5c6d73ebe0e: Pulling fs layer
e5c6d73ebe0e: Waiting
91d30c5bc195: Verifying Checksum
91d30c5bc195: Download complete
65d52c8ad3c4: Verifying Checksum
65d52c8ad3c4: Download complete
e5c6d73ebe0e: Verifying Checksum
e5c6d73ebe0e: Download complete
91d30c5bc195: Pull complete
65d52c8ad3c4: Pull complete
fd88c46576ef: Verifying Checksum
fd88c46576ef: Download complete
fd88c46576ef: Pull complete
e5c6d73ebe0e: Pull complete
Digest: sha256:6469405d7297f82d56195c90a3270b0806ef4bd897aa0628477d9959ab97a577
Status: Downloaded newer image for golang:1.20-alpine3.16
 ---> 6d6f0b18cc7e
Step 2/16 : RUN apk update
 ---> Running in 9ef8b7ac936f
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
v3.16.9-124-g7ebe731c813 [https://dl-cdn.alpinelinux.org/alpine/v3.16/main]
v3.16.9-125-gec300a94000 [https://dl-cdn.alpinelinux.org/alpine/v3.16/community]
OK: 17049 distinct packages available
Removing intermediate container 9ef8b7ac936f
 ---> b7e72fbc1b70
Step 3/16 : RUN apk add git
 ---> Running in 4d712f5e4dec
(1/6) Installing brotli-libs (1.0.9-r6)
(2/6) Installing nghttp2-libs (1.47.0-r2)
(3/6) Installing libcurl (8.5.0-r0)
(4/6) Installing expat (2.6.2-r0)
(5/6) Installing pcre2 (10.42-r0)
(6/6) Installing git (2.36.6-r0)
Executing busybox-1.35.0-r17.trigger
OK: 20 MiB in 21 packages
Removing intermediate container 4d712f5e4dec
 ---> ac4da6813a5d
Step 4/16 : WORKDIR /app
 ---> Running in 1144255f0e32
Removing intermediate container 1144255f0e32
 ---> 6929188e73f1
Step 5/16 : COPY go.mod ./
 ---> 409cf1a2a3ba
Step 6/16 : COPY go.sum ./
 ---> 3473b3ed6c49
Step 7/16 : RUN go mod download
 ---> Running in 11a5ad56384a
Removing intermediate container 11a5ad56384a
 ---> c5fcaf9d80b7
Step 8/16 : COPY . ./
 ---> 43dcc4cf301f
Step 9/16 : RUN go build -o /app/comqtt ./cmd/single
 ---> Running in 787bde132647
cluster/log/default_logger.go:6:2: package log/slog is not in GOROOT (/usr/local/go/src/log/slog)
note: imported by a module that requires go 1.21
The command '/bin/sh -c go build -o /app/comqtt ./cmd/single' returned a non-zero code: 1
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 1
```