### PR TITLE
Fix CI

### DIFF
--- a/cmd/single/main_test.go
+++ b/cmd/single/main_test.go
@@ -2,20 +2,25 @@ package main
 
 import (
 	"context"
-	"go.uber.org/goleak"
 	"sync"
 	"testing"
 	"time"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
+	)
 }
 
 // TestLeaks tests that there are no goroutine leaks after starting and stopping the server.
 // We should likely do some more operations here, but this is a start.
 func TestLeaks(t *testing.T) {
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
+	)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
Fix:

```
--- FAIL: TestLeaks (0.55s)
    main_test.go:34: found unexpected goroutines:
        [Goroutine 34 in state select, with github.com/golang/glog.(*fileSink).flushDaemon on top of the stack:
        github.com/golang/glog.(*fileSink).flushDaemon(0x158d2b8)
        	/home/runner/go/pkg/mod/github.com/golang/glog@v1.2.1/glog_file.go:351 +0xb9
        created by github.com/golang/glog.init.1 in goroutine 1
        	/home/runner/go/pkg/mod/github.com/golang/glog@v1.2.1/glog_file.go:166 +0x135
        ]
FAIL
FAIL	github.com/wind-c/comqtt/v2/cmd/single	0.558s
```

Maybe either VerifyTestMain or VerifyNone would be enough.