### PR TITLE
Fix to always use the derived port for memberlist

### DIFF
--- a/cluster/agent.go
+++ b/cluster/agent.go
@@ -73,11 +73,8 @@ func NewAgent(conf *config.Cluster) *Agent {
 
 func (a *Agent) Start() (err error) {
 	// setup raft
-	if a.Config.DiscoveryWay == config.DiscoveryWayMemberlist {
+	if a.Config.RaftPort == 0 || a.Config.DiscoveryWay == config.DiscoveryWayMemberlist {
 		a.Config.RaftPort = mlist.GetRaftPortFromBindPort(a.Config.BindPort)
-	}
-	if a.Config.RaftPort == 0 {
-		a.Config.RaftPort = 8946
 	}
 	if a.Config.RaftDir == "" {
 		a.Config.RaftDir = path.Join("data", a.Config.NodeName)

--- a/cluster/agent.go
+++ b/cluster/agent.go
@@ -73,6 +73,9 @@ func NewAgent(conf *config.Cluster) *Agent {
 
 func (a *Agent) Start() (err error) {
 	// setup raft
+	if a.Config.DiscoveryWay == config.DiscoveryWayMemberlist {
+		a.Config.RaftPort = mlist.GetRaftPortFromBindPort(a.Config.BindPort)
+	}
 	if a.Config.RaftPort == 0 {
 		a.Config.RaftPort = 8946
 	}
@@ -208,7 +211,7 @@ func getRaftPeerAddr(member *discovery.Member) string {
 	}
 
 	// using memberlist
-	return net.JoinHostPort(member.Addr, strconv.Itoa(member.Port+1000))
+	return net.JoinHostPort(member.Addr, strconv.Itoa(mlist.GetRaftPortFromBindPort(member.Port)))
 }
 
 func getGrpcAddr(member *discovery.Member) string {
@@ -218,7 +221,7 @@ func getGrpcAddr(member *discovery.Member) string {
 	}
 
 	// using memberlist
-	return net.JoinHostPort(member.Addr, strconv.Itoa(member.Port+10000))
+	return net.JoinHostPort(member.Addr, strconv.Itoa(mlist.GetGRPCPortFromBindPort(member.Port)))
 }
 
 func (a *Agent) Stat() map[string]int64 {

--- a/cluster/discovery/mlist/port.go
+++ b/cluster/discovery/mlist/port.go
@@ -1,0 +1,12 @@
+package mlist
+
+// serf.Member has Tags, but memberlist.Node does not, so the Raft and gRPC ports cannot be relayed through events.
+// Ports are derived based on the bind port instead.
+
+func GetRaftPortFromBindPort(bindPort int) int {
+	return bindPort + 1000
+}
+
+func GetGRPCPortFromBindPort(bindPort int) int {
+	return bindPort + 10000
+}


### PR DESCRIPTION
Currently, for gRPC and Raft, the ports derived from the bind ports are used in the case of memberlist.
There are cases where Raft uses port 8946 with memberlist, and this change prevents that from happening.

