### PR TITLE
testCluster: Add etcd integration tests

### DIFF
--- a/cluster/raft/etcd/peer.go
+++ b/cluster/raft/etcd/peer.go
@@ -368,6 +368,7 @@ func (p *Peer) serveChannels() {
 			return
 
 		case <-p.stopC:
+			//p.Stop()
 			return
 		}
 	}

--- a/cluster/raft/etcd/peer.go
+++ b/cluster/raft/etcd/peer.go
@@ -368,7 +368,6 @@ func (p *Peer) serveChannels() {
 			return
 
 		case <-p.stopC:
-			p.Stop()
 			return
 		}
 	}
@@ -603,6 +602,8 @@ func (p *Peer) writeError(err error) {
 
 func (p *Peer) Stop() {
 	p.stopHTTP()
+	close(p.proposeC)
+	close(p.confChangeC)
 	close(p.commitC)
 	close(p.errorC)
 	p.node.Stop()


### PR DESCRIPTION
In peer.go, there was an issue where stopC should close when proposeC and confChangeC are closed, but proposeC and confChangeC were not being closed.
I have fixed this.
