### PR TITLE
fix: correct ACL access level annotations in config files

### DIFF
--- a/cmd/config/auth-mysql.yml
+++ b/cmd/config/auth-mysql.yml
@@ -23,4 +23,4 @@ acl:
   table: acl
   user-column: username # or client_id, set this parameter based on the actual field name
   topic-column: topic
-  access-column: access  # 0 Deny、1 publish (Write)、2 subscribe (Read)、3 pubsub (ReadWrite)
+  access-column: access  # 0 Deny, 1 subscribe (Read), 2 publish (Write), 3 pubsub (ReadWrite)

--- a/cmd/config/auth-postgresql.yml
+++ b/cmd/config/auth-postgresql.yml
@@ -23,7 +23,7 @@ acl:
   table: acl
   user-column: username  # or client_id, set this parameter based on the actual field name
   topic-column: topic
-  access-column: access  # 1 publish、2 subscribe、3 pubsub
+  access-column: access  # 0 Deny, 1 subscribe (Read), 2 publish (Write), 3 pubsub (ReadWrite)
   publish: 1  #result returned with publish permission
   subscribe: 2  #result returned with subscribe permission
   pubsub: 3  #result returned with publish and subscribe permission

--- a/plugin/auth/mysql/testdata/conf.yml
+++ b/plugin/auth/mysql/testdata/conf.yml
@@ -23,4 +23,4 @@ acl:
   table: acl
   user-column: username
   topic-column: topic
-  access-column: access  # 0 Deny、1 publish (Write)、2 subscribe (Read)、3 pubsub (ReadWrite)
+  access-column: access  # 0 Deny, 1 subscribe (Read), 2 publish (Write), 3 pubsub (ReadWrite)

--- a/plugin/auth/postgresql/testdata/conf.yml
+++ b/plugin/auth/postgresql/testdata/conf.yml
@@ -23,7 +23,7 @@ acl:
   table: acl
   user-column: username
   topic-column: topic
-  access-column: access  # 1 publish、2 subscribe、3 pubsub
+  access-column: access  # 0 Deny, 1 subscribe (Read), 2 publish (Write), 3 pubsub (ReadWrite)
   publish: 1  #result returned with publish permission
   subscribe: 2  #result returned with subscribe permission
   pubsub: 3  #result returned with publish and subscribe permission


### PR DESCRIPTION
## Summary

Fixes incorrect ACL access level comments in MySQL and PostgreSQL auth configuration files and their testdata counterparts.

## Problem

The comments in the config files incorrectly mapped access levels as:
- `1 = publish (Write), 2 = subscribe (Read)`

However, the actual constants in `mqtt/hooks/auth/ledger.go` are:
- `0 = Deny`
- `1 = ReadOnly (subscribe)`
- `2 = WriteOnly (publish)`
- `3 = ReadWrite (pubsub)`

This mismatch caused users to configure ACL rules incorrectly, leading to unexpected access denials (as reported in #127).

## Changes

- `cmd/config/auth-mysql.yml`
- `cmd/config/auth-postgresql.yml`
- `plugin/auth/mysql/testdata/conf.yml`
- `plugin/auth/postgresql/testdata/conf.yml`

All files now correctly document the access level mapping.

Fixes #127