### PR TITLE
fix: unblock Peer.Stop deadlock and QUIC test port collision

### DIFF
--- a/cluster/raft/etcd/peer.go
+++ b/cluster/raft/etcd/peer.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/wind-c/comqtt/v2/cluster/log"
@@ -74,6 +75,7 @@ type Peer struct {
 	stopC     chan struct{} // signals proposal channel closed
 	httpStopC chan struct{} // signals http server to shutdown
 	httpDoneC chan struct{} // signals http server shutdown complete
+	stopOnce  sync.Once     // guards Stop so it's safe to call from multiple goroutines
 
 	logger *zap.Logger
 }
@@ -288,6 +290,8 @@ func (p *Peer) startRaft() {
 }
 
 func (p *Peer) serveRaft() {
+	defer close(p.httpDoneC)
+
 	addr := net.JoinHostPort(p.conf.BindAddr, strconv.Itoa(p.conf.RaftPort))
 	listener, err := newStoppableListener(addr, p.httpStopC)
 	if err != nil {
@@ -320,25 +324,25 @@ func (p *Peer) serveChannels() {
 	// send proposals over raft
 	go func() {
 		confChangeCount := uint64(0)
+		proposeC := p.proposeC
+		confChangeC := p.confChangeC
 
-		for p.proposeC != nil && p.confChangeC != nil {
+		for proposeC != nil || confChangeC != nil {
 			select {
 			case <-p.stopC:
 				return
-			case prop, ok := <-p.proposeC:
+			case prop, ok := <-proposeC:
 				if !ok {
-					close(p.proposeC)
-					p.proposeC = nil
+					proposeC = nil
 				} else {
 					if err := p.node.Propose(context.TODO(), prop.MsgpackBytes()); err != nil {
 						log.Error("Propose", "error", err, "filter", prop.Payload, "nid", prop.NodeID, "type", prop.Type)
 					}
 				}
 
-			case cc, ok := <-p.confChangeC:
+			case cc, ok := <-confChangeC:
 				if !ok {
-					close(p.confChangeC)
-					p.confChangeC = nil
+					confChangeC = nil
 				} else {
 					confChangeCount++
 					cc.ID = confChangeCount
@@ -348,11 +352,10 @@ func (p *Peer) serveChannels() {
 				}
 			}
 		}
-		// client closed channel; shutdown raft if not ready
-		close(p.stopC)
 	}()
 
 	// event loop on raft state machine updates
+	defer p.shutdown()
 	for {
 		select {
 		case <-ticker.C:
@@ -390,7 +393,6 @@ func (p *Peer) serveChannels() {
 			return
 
 		case <-p.stopC:
-			p.Stop()
 			return
 		}
 	}
@@ -616,12 +618,32 @@ func (p *Peer) processMessages(ms []raftpb.Message) []raftpb.Message {
 }
 
 func (p *Peer) writeError(err error) {
-	p.errorC <- err
+	select {
+	case p.errorC <- err:
+	case <-p.stopC:
+	}
 	p.Stop()
 }
 
+// Stop signals the peer's goroutines to shut down. Safe to call from any
+// goroutine, including from inside serveChannels itself; subsequent calls
+// are no-ops. Channel/transport/node teardown happens in serveChannels'
+// deferred shutdown so the event loop never sees a half-torn-down peer.
 func (p *Peer) Stop() {
+	p.stopOnce.Do(func() {
+		close(p.stopC)
+	})
+}
+
+// shutdown is invoked by serveChannels on exit (deferred). It tears down
+// resources owned by the peer in a fixed order. Running it from a single
+// goroutine on a single path means the event loop never races with Stop().
+func (p *Peer) shutdown() {
 	p.stopHTTP()
+	if p.node != nil {
+		p.node.Stop()
+		p.node = nil
+	}
 	if p.commitC != nil {
 		close(p.commitC)
 		p.commitC = nil
@@ -634,15 +656,16 @@ func (p *Peer) Stop() {
 		close(p.confChangeC)
 		p.confChangeC = nil
 	}
-	if p.node != nil {
-		p.node.Stop()
-		p.node = nil
-	}
 }
 
 func (p *Peer) stopHTTP() {
 	p.transport.Stop()
-	close(p.httpStopC)
+	select {
+	case <-p.httpStopC:
+		// already closed
+	default:
+		close(p.httpStopC)
+	}
 	<-p.httpDoneC
 }
 

--- a/mqtt/listeners/quic_test.go
+++ b/mqtt/listeners/quic_test.go
@@ -14,29 +14,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// quicTestAddr binds to an OS-assigned ephemeral UDP port so that
+// successive QUIC tests don't fight over the same fixed port - the
+// previous test's UDP socket isn't always released by quic-go quickly
+// enough for the next test to reuse it.
+const quicTestAddr = ":0"
+
 func TestNewQUIC(t *testing.T) {
-	l := NewQUIC("t1", testAddr, nil)
+	l := NewQUIC("t1", quicTestAddr, nil)
 	require.Equal(t, "t1", l.id)
-	require.Equal(t, testAddr, l.address)
+	require.Equal(t, quicTestAddr, l.address)
 }
 
 func TestQUICID(t *testing.T) {
-	l := NewQUIC("t1", testAddr, nil)
+	l := NewQUIC("t1", quicTestAddr, nil)
 	require.Equal(t, "t1", l.ID())
 }
 
 func TestQUICAddress(t *testing.T) {
-	l := NewQUIC("t1", testAddr, nil)
-	require.Equal(t, testAddr, l.Address())
+	l := NewQUIC("t1", quicTestAddr, nil)
+	require.Equal(t, quicTestAddr, l.Address())
 }
 
 func TestQUICProtocol(t *testing.T) {
-	l := NewQUIC("t1", testAddr, nil)
+	l := NewQUIC("t1", quicTestAddr, nil)
 	require.Equal(t, "quic", l.Protocol())
 }
 
 func TestQUICInit(t *testing.T) {
-	l := NewQUIC("t2", testAddr, &Config{
+	l := NewQUIC("t2", quicTestAddr, &Config{
 		TLSConfig: tlsConfigBasic,
 	})
 	err := l.Init(logger)
@@ -46,7 +52,7 @@ func TestQUICInit(t *testing.T) {
 }
 
 func TestQUICServeAndClose(t *testing.T) {
-	l := NewQUIC("t1", testAddr, &Config{
+	l := NewQUIC("t1", quicTestAddr, &Config{
 		TLSConfig: tlsConfigBasic,
 	})
 	err := l.Init(logger)
@@ -79,7 +85,7 @@ func TestQUICEstablishThenEnd(t *testing.T) {
 	tlsConfig.InsecureSkipVerify = true
 	tlsConfig.KeyLogWriter = os.Stdout
 	tlsConfig.NextProtos = []string{"mqtt"}
-	l := NewQUIC("t1", testAddr, &Config{
+	l := NewQUIC("t1", quicTestAddr, &Config{
 		TLSConfig: tlsConfig,
 	})
 	err := l.Init(logger)
@@ -113,7 +119,7 @@ func TestQUICRTTEstablishThenEnd(t *testing.T) {
 	tlsConfig.InsecureSkipVerify = true
 	tlsConfig.KeyLogWriter = os.Stdout
 	tlsConfig.NextProtos = []string{"mqtt"}
-	l := NewQUIC("t1", testAddr, &Config{
+	l := NewQUIC("t1", quicTestAddr, &Config{
 		TLSConfig: tlsConfig,
 	})
 	err := l.Init(logger)


### PR DESCRIPTION
Two pre-existing CI flakes that fail on every `go test -v ./...` run. They're independent bugs but each one's CI hits the other, so they're combined here.

## 1. `cluster/raft/etcd` — `Peer.Stop()` deadlocks for 600s

`serveRaft` never closed `httpDoneC`, so `stopHTTP`'s `<-p.httpDoneC` blocked forever — `TestJoinAndLeave` timed out at the 10-minute mark on every CI run.

After unblocking the HTTP wait, the next `serveChannels` iteration races `Stop()` setting `p.node = nil`, producing `close of nil channel` and nil-pointer panics in `TestProposeAndLookup`/`TestGetLeader`.

**Fix:**
- `serveRaft` now `defer close(p.httpDoneC)` so the HTTP shutdown wait always completes.
- Centralize teardown in `serveChannels` via deferred `shutdown()`.
- `Stop()` becomes a thin idempotent signal (`sync.Once` → `close(stopC)`), safe to call from any goroutine including from inside `serveChannels` itself.
- Propose-loop uses local channel variables and exits cleanly on `stopC` without re-closing channels it doesn't own.

## 2. `mqtt/listeners` — QUIC tests collide on UDP `:22222`

The four QUIC tests that bind a real UDP socket all share the package-wide `testAddr = ":22222"`. quic-go doesn't always release the socket between sequential tests, producing intermittent `listen udp :22222: bind: address already in use` failures.

**Fix:** switch the QUIC tests to `:0` so the OS picks a fresh port each time. Tests already read the bound port back via `l.listen.Addr()`. `testAddr` stays unchanged for the other listener tests, which depend on its literal value via URL string concatenation.

## Test plan

- [x] `go test -timeout 120s -count=1 ./cluster/raft/etcd/ ./mqtt/listeners/` — 81/81 pass locally
- [x] `go test -count=5 -run TestQUIC ./mqtt/listeners/` — 40/40 pass (port reuse no longer flakes)
- [x] `go test -timeout 120s -count=1 ./cluster/...` — 86/86 pass
- [ ] Upstream CI green