### PR TITLE
feat(helm): wire dashboard.* values + Secret-mounted session secret into chart

### DIFF
--- a/deploy/helm/comqtt/Chart.yaml
+++ b/deploy/helm/comqtt/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   comqtt — a lightweight, high-performance MQTT broker (v3.0/v3.1.1/v5.0)
   supporting standalone and clustered (Raft + Gossip) deployments.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "2.6.0"
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/wind-c/comqtt
@@ -25,7 +25,7 @@ icon: https://raw.githubusercontent.com/wind-c/comqtt/main/README.md
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Initial Helm chart with single-node and clustered deployment modes (resolves #137).
+      description: dashboard.* values block plus Secret-mounted session secret and initial password (follow-up to #151).
   artifacthub.io/license: MIT
 ## Bitnami sub-charts intentionally omitted: as of 2025 the public bitnami/*
 ## Docker images are behind authentication. Bring your own Redis/Valkey,

--- a/deploy/helm/comqtt/README.md
+++ b/deploy/helm/comqtt/README.md
@@ -136,6 +136,14 @@ is rejected by the schema.
 | `secret.data` | map | `{}` | Keys become file names under `/etc/comqtt/secrets`. |
 | `serviceMonitor.enabled` | bool | `false` | kube-prometheus-stack. |
 | `tests.enabled` | bool | `true` | `helm test` mosquitto pod. |
+| `dashboard.enabled` | bool | `true` | Embedded web dashboard (broker default). |
+| `dashboard.passwordExpiryDays` | int | `90` | 0 disables. |
+| `dashboard.sessionSecret.existingSecret` | string | `""` | Pre-created Secret holding the HMAC session secret. |
+| `dashboard.sessionSecret.key` | string | `session-secret` | Key inside the Secret. |
+| `dashboard.sessionSecret.value` | string | `""` | Inline secret rendered into a chart-managed Secret. |
+| `dashboard.initialPassword.existingSecret` | string | `""` | Pre-created Secret holding the initial admin password. |
+| `dashboard.initialPassword.key` | string | `initial-password` | Key inside the Secret. |
+| `dashboard.initialPassword.value` | string | `""` | Inline initial password rendered into a chart-managed Secret. |
 
 For the full list of `config.*` keys (storage, auth, mqtt, redis, log) see
 [cmd/config/single.yml](https://github.com/wind-c/comqtt/blob/main/cmd/config/single.yml)

--- a/deploy/helm/comqtt/templates/_helpers.tpl
+++ b/deploy/helm/comqtt/templates/_helpers.tpl
@@ -99,3 +99,47 @@ Render the rendered config (single-mode — used as-is) or the template config
 {{- define "comqtt.configYaml" -}}
 {{- toYaml .Values.config | nindent 0 -}}
 {{- end -}}
+
+{{/*
+Name of the chart-managed dashboard Secret (session secret + initial password).
+*/}}
+{{- define "comqtt.dashboardSecretName" -}}
+{{- printf "%s-dashboard" (include "comqtt.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Whether the chart should render its own dashboard Secret (i.e. at least one of
+the inline values is set and no existingSecret overrides it).
+*/}}
+{{- define "comqtt.dashboardSecretCreate" -}}
+{{- $d := .Values.dashboard -}}
+{{- $sess := and (not $d.sessionSecret.existingSecret) $d.sessionSecret.value -}}
+{{- $pw := and (not $d.initialPassword.existingSecret) $d.initialPassword.value -}}
+{{- if or $sess $pw -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Env entries that wire the dashboard session secret + initial password from
+Secret references into the broker container. Emits nothing when neither is
+configured.
+*/}}
+{{- define "comqtt.dashboardEnv" -}}
+{{- if .Values.dashboard.enabled -}}
+{{- $d := .Values.dashboard -}}
+{{- $managed := include "comqtt.dashboardSecretName" . -}}
+{{- if or $d.sessionSecret.existingSecret $d.sessionSecret.value }}
+- name: COMQTT_DASHBOARD_SESSION_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ default $managed $d.sessionSecret.existingSecret | quote }}
+      key: {{ $d.sessionSecret.key | quote }}
+{{- end }}
+{{- if or $d.initialPassword.existingSecret $d.initialPassword.value }}
+- name: DASHBOARD_INITIAL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ default $managed $d.initialPassword.existingSecret | quote }}
+      key: {{ $d.initialPassword.key | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/deploy/helm/comqtt/templates/configmap.yaml
+++ b/deploy/helm/comqtt/templates/configmap.yaml
@@ -16,12 +16,21 @@ metadata:
   labels:
     {{- include "comqtt.labels" . | nindent 4 }}
 data:
+{{- $cfgBase := deepCopy .Values.config -}}
+{{- if .Values.dashboard.enabled -}}
+{{- $_ := set $cfgBase "dashboard" (dict
+    "enabled" true
+    "session-secret" ""
+    "password-expiry-days" (.Values.dashboard.passwordExpiryDays | int)) -}}
+{{- else -}}
+{{- $_ := set $cfgBase "dashboard" (dict "enabled" false) -}}
+{{- end -}}
 {{- if eq .Values.mode "single" }}
   config.yml: |
-{{- tpl (toYaml .Values.config) . | nindent 4 }}
+{{- tpl (toYaml $cfgBase) . | nindent 4 }}
 {{- else }}
   config.tpl.yml: |
-{{- $cfg := deepCopy .Values.config -}}
+{{- $cfg := $cfgBase -}}
 {{- /* Inject cluster-mode keys into the templated config. */ -}}
 {{- $_ := set $cfg "storage-way" 3 -}}
 {{- $cluster := dict

--- a/deploy/helm/comqtt/templates/dashboard-secret.yaml
+++ b/deploy/helm/comqtt/templates/dashboard-secret.yaml
@@ -1,0 +1,16 @@
+{{- if eq (include "comqtt.dashboardSecretCreate" .) "true" -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comqtt.dashboardSecretName" . }}
+  labels:
+    {{- include "comqtt.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- with .Values.dashboard.sessionSecret.value }}
+  {{ $.Values.dashboard.sessionSecret.key }}: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.dashboard.initialPassword.value }}
+  {{ $.Values.dashboard.initialPassword.key }}: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/comqtt/templates/deployment.yaml
+++ b/deploy/helm/comqtt/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
           command: ["/comqtt"]
           args:
             - --conf=/etc/comqtt/config.yml
+          {{- with (include "comqtt.dashboardEnv" . | trim) }}
+          env:
+            {{- . | nindent 12 }}
+          {{- end }}
           ports:
             - name: mqtt
               containerPort: 1883

--- a/deploy/helm/comqtt/templates/statefulset.yaml
+++ b/deploy/helm/comqtt/templates/statefulset.yaml
@@ -85,6 +85,7 @@ spec:
               value: {{ .Values.cluster.gossipPort | quote }}
             - name: RAFT_DIR
               value: /data/raft
+            {{- include "comqtt.dashboardEnv" . | nindent 12 }}
           ports:
             - name: mqtt
               containerPort: 1883

--- a/deploy/helm/comqtt/values.schema.json
+++ b/deploy/helm/comqtt/values.schema.json
@@ -131,6 +131,15 @@
         "labels": { "type": "object" }
       }
     },
+    "dashboard": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "passwordExpiryDays": { "type": "integer", "minimum": 0 },
+        "sessionSecret": { "$ref": "#/$defs/secretRef" },
+        "initialPassword": { "$ref": "#/$defs/secretRef" }
+      }
+    },
     "tests": {
       "type": "object",
       "properties": {
@@ -170,6 +179,14 @@
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "nodePort": { "type": ["integer", "string"] },
         "annotations": { "type": "object" }
+      }
+    },
+    "secretRef": {
+      "type": "object",
+      "properties": {
+        "existingSecret": { "type": "string" },
+        "key": { "type": "string", "minLength": 1 },
+        "value": { "type": "string" }
       }
     }
   }

--- a/deploy/helm/comqtt/values.yaml
+++ b/deploy/helm/comqtt/values.yaml
@@ -267,6 +267,36 @@ serviceMonitor:
   scrapeTimeout: 10s
   labels: {}
 
+# Embedded web dashboard. Mounts on the dashboard HTTP port (8080) alongside
+# the existing /api/v1 admin API. Requires comqtt with the dashboard feature
+# (PR #151); on older images the chart values are inert.
+dashboard:
+  # -- Enable the embedded web dashboard. Defaults match the broker default.
+  enabled: true
+  # -- Password expiry in days. 0 disables expiry.
+  passwordExpiryDays: 90
+  # Session HMAC secret. Pin one across pod restarts so login cookies survive
+  # rolling updates. In cluster mode the broker prefers a redis-backed shared
+  # secret automatically; this block is then a fallback if redis is unreachable
+  # at boot. Provide either an existing Secret reference or an inline value
+  # (rendered into a chart-managed Secret named `<release>-dashboard`).
+  sessionSecret:
+    # -- Source from an existing Secret. Takes precedence over `value`.
+    existingSecret: ""
+    # -- Key inside the Secret. Value must be base64 (>= 16 raw bytes) or raw.
+    key: session-secret
+    # -- Inline value (base64 or raw). Rendered into the chart-managed Secret.
+    value: ""
+  # Initial admin password. If unset, the broker prints a random password to
+  # stdout on first boot (`kubectl logs ...`). After first login, change it.
+  initialPassword:
+    # -- Source from an existing Secret. Takes precedence over `value`.
+    existingSecret: ""
+    # -- Key inside the Secret.
+    key: initial-password
+    # -- Inline value. Rendered into the chart-managed Secret.
+    value: ""
+
 # -- Test pod settings (used by `helm test`).
 tests:
   enabled: true


### PR DESCRIPTION
Follow-up to #150 (chart) and #151 (dashboard). Adds the `dashboard.*` values block + Secret-mounted session secret + initial admin password wiring that #151's PR description marked as deferred.

> ⚠️ **Hold for #151 to merge first.** This PR is opened as a draft because the chart values are inert until the broker side ships in #151. Once #151 lands and the GHCR image rebuilds with the dashboard binary embedded, this can come out of draft and merge.

## What's in

### `values.yaml` — new `dashboard:` block

```yaml
dashboard:
  enabled: true              # broker default
  passwordExpiryDays: 90     # 0 disables
  sessionSecret:
    existingSecret: ""       # reference an existing Secret
    key: session-secret
    value: ""                # OR inline; rendered into <release>-dashboard
  initialPassword:
    existingSecret: ""
    key: initial-password
    value: ""
```

### Wiring

- **ConfigMap** gains a `dashboard:` block (`enabled`, `password-expiry-days`) injected into the rendered broker config for both single and cluster modes. The session secret deliberately stays out of the ConfigMap so it never lands in plaintext-rendered manifests.
- **Deployment + StatefulSet** containers get an `env:` block via a new `comqtt.dashboardEnv` helper that wires `COMQTT_DASHBOARD_SESSION_SECRET` and `DASHBOARD_INITIAL_PASSWORD` from the configured Secret (existing or chart-managed).
- New `templates/dashboard-secret.yaml` renders a chart-managed `<release>-dashboard` Secret only when at least one inline value is provided. If everything points at existing Secrets, no chart-managed Secret is created.
- `values.schema.json` gains a `dashboard` schema with a reusable `secretRef` `$def`.

### Cluster-mode note

The broker auto-shares an HMAC secret across cluster nodes via Redis (`comqtt:dashboard:secret`) when Redis is configured. The env-mounted `COMQTT_DASHBOARD_SESSION_SECRET` then acts as a fallback if Redis is unreachable on boot. So in normal cluster operation the chart-side Secret is optional; in single-mode it's the only way to keep login cookies surviving a pod restart.

## Verification (`helm template ci .`)

| Path | Result |
|---|---|
| Default values (single) | `dashboard:` block in ConfigMap, no `env:` block, no chart Secret rendered |
| `sessionSecret.value=...`, `initialPassword.existingSecret=my-existing` | Managed Secret rendered with `session-secret` key; env wires session to managed, initial password to `my-existing/admin-pw` |
| `mode=cluster, replicaCount=3, initialPassword.value=...` | StatefulSet env extends after the existing entrypoint env vars; cluster ConfigMap gains the dashboard block |
| `dashboard.enabled=false` | `dashboard: { enabled: false }` only, no env, no Secret |

`helm lint .` clean.

## Out of scope

- **Gateway API support** (per @sansmoraxz's feedback on #150 about ingress-nginx retirement) — opening that as a separate PR so this one stays focused on values plumbing.