### PR TITLE
feat(helm): Gateway API support; deprecate Ingress

### DIFF
--- a/deploy/helm/comqtt/Chart.yaml
+++ b/deploy/helm/comqtt/Chart.yaml
@@ -25,7 +25,7 @@ icon: https://raw.githubusercontent.com/wind-c/comqtt/main/README.md
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Gateway API support — HTTPRoute (dashboard) and TCPRoute (MQTT).
+      description: Gateway API support, HTTPRoute (REST API + /metrics) and TCPRoute (MQTT).
     - kind: deprecated
       description: ingress.* (use gateway.* instead).
   artifacthub.io/license: MIT

--- a/deploy/helm/comqtt/Chart.yaml
+++ b/deploy/helm/comqtt/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   comqtt — a lightweight, high-performance MQTT broker (v3.0/v3.1.1/v5.0)
   supporting standalone and clustered (Raft + Gossip) deployments.
 type: application
-version: 0.1.0
+version: 0.3.0
 appVersion: "2.6.0"
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/wind-c/comqtt
@@ -25,7 +25,9 @@ icon: https://raw.githubusercontent.com/wind-c/comqtt/main/README.md
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Initial Helm chart with single-node and clustered deployment modes (resolves #137).
+      description: Gateway API support — HTTPRoute (dashboard) and TCPRoute (MQTT).
+    - kind: deprecated
+      description: ingress.* (use gateway.* instead).
   artifacthub.io/license: MIT
 ## Bitnami sub-charts intentionally omitted: as of 2025 the public bitnami/*
 ## Docker images are behind authentication. Bring your own Redis/Valkey,

--- a/deploy/helm/comqtt/README.md
+++ b/deploy/helm/comqtt/README.md
@@ -115,12 +115,12 @@ is rejected by the schema.
 | `service.mqtt.{type,port,nodePort}` | — | `ClusterIP / 1883` | |
 | `service.ws.{type,port,nodePort}` | — | `ClusterIP / 1882` | |
 | `service.dashboard.{type,port,nodePort}` | — | `ClusterIP / 8080` | |
-| `ingress.enabled` | bool | `false` | **DEPRECATED.** Use `gateway.*`. Dashboard only. |
+| `ingress.enabled` | bool | `false` | **DEPRECATED.** Use `gateway.*`. HTTP listener only. |
 | `gateway.enabled` | bool | `false` | Master toggle for Gateway API resources. |
 | `gateway.parentRefs` | list | `[]` | Default `parentRefs` for both routes. |
-| `gateway.dashboard.enabled` | bool | `true` | Emit `HTTPRoute` for the dashboard. |
-| `gateway.dashboard.hostnames` | list | `[]` | HTTPRoute hostnames. |
-| `gateway.dashboard.matches` | list | PathPrefix `/` | HTTPRoute path matches. |
+| `gateway.api.enabled` | bool | `true` | Emit `HTTPRoute` for the broker's HTTP listener (REST + metrics). |
+| `gateway.api.hostnames` | list | `[]` | HTTPRoute hostnames. |
+| `gateway.api.matches` | list | PathPrefix `/` | HTTPRoute path matches. |
 | `gateway.mqtt.enabled` | bool | `false` | Emit `TCPRoute` for raw MQTT (alpha API). |
 | `tls.enabled` | bool | `false` | |
 | `tls.existingSecret` | string | `""` | Pre-created Secret with tls.crt/tls.key/ca.crt. |
@@ -163,7 +163,10 @@ You bring the `Gateway` resource and a Gateway API provider. Examples:
 
 The chart emits:
 
-- `HTTPRoute` for the dashboard (`gateway.dashboard.enabled`, default on)
+- `HTTPRoute` for the broker's HTTP listener on port 8080
+  (`gateway.api.enabled`, default on). This serves the existing `/api/v1/*`
+  REST surface and `/metrics`. Most users will not expose this externally;
+  flip the toggle off if you don't need it.
 - `TCPRoute` for raw MQTT (`gateway.mqtt.enabled`, default off — TCPRoute is
   in `gateway.networking.k8s.io/v1alpha2` and requires a TCP-aware provider)
 
@@ -176,7 +179,7 @@ gateway:
   parentRefs:
     - name: eg
       namespace: envoy-gateway-system
-  dashboard:
+  api:
     enabled: true
     hostnames: ["comqtt.example.com"]
   mqtt:
@@ -193,7 +196,7 @@ If Gateway API is not available in your cluster:
 
 - `service.mqtt.type: LoadBalancer` — straightforward on cloud providers.
 - A NodePort plus an external load balancer or DNS round-robin.
-- `ingress.*` (deprecated; dashboard only).
+- `ingress.*` (deprecated; HTTP listener only, cannot proxy raw MQTT).
 
 ## Upgrades
 
@@ -223,10 +226,10 @@ If Gateway API is not available in your cluster:
 - No bundled RESP store. The chart expects an externally-deployed Redis or
   Valkey (see [ci/valkey.yaml](ci/valkey.yaml) for a starting point) — the
   chart does not manage failover or HA for it.
-- The dashboard `HTTPRoute` defaults to `PathPrefix /`. Override
-  `gateway.dashboard.matches` to mount under a sub-path; the dashboard's
-  embedded asset paths assume `/dashboard/`, so a sub-path mount needs an
-  HTTPRoute filter (`URLRewrite`) to strip the prefix before forwarding.
+- The HTTP `HTTPRoute` defaults to `PathPrefix /`. Override
+  `gateway.api.matches` to mount under a sub-path; consumers expecting
+  routes at `/api/v1/...` and `/metrics` will need an HTTPRoute filter
+  (`URLRewrite`) to strip the prefix before forwarding.
 
 ## Contributing
 

--- a/deploy/helm/comqtt/README.md
+++ b/deploy/helm/comqtt/README.md
@@ -115,7 +115,13 @@ is rejected by the schema.
 | `service.mqtt.{type,port,nodePort}` | — | `ClusterIP / 1883` | |
 | `service.ws.{type,port,nodePort}` | — | `ClusterIP / 1882` | |
 | `service.dashboard.{type,port,nodePort}` | — | `ClusterIP / 8080` | |
-| `ingress.enabled` | bool | `false` | Dashboard only. |
+| `ingress.enabled` | bool | `false` | **DEPRECATED.** Use `gateway.*`. Dashboard only. |
+| `gateway.enabled` | bool | `false` | Master toggle for Gateway API resources. |
+| `gateway.parentRefs` | list | `[]` | Default `parentRefs` for both routes. |
+| `gateway.dashboard.enabled` | bool | `true` | Emit `HTTPRoute` for the dashboard. |
+| `gateway.dashboard.hostnames` | list | `[]` | HTTPRoute hostnames. |
+| `gateway.dashboard.matches` | list | PathPrefix `/` | HTTPRoute path matches. |
+| `gateway.mqtt.enabled` | bool | `false` | Emit `TCPRoute` for raw MQTT (alpha API). |
 | `tls.enabled` | bool | `false` | |
 | `tls.existingSecret` | string | `""` | Pre-created Secret with tls.crt/tls.key/ca.crt. |
 | `tls.certManager.enabled` | bool | `false` | |
@@ -143,17 +149,51 @@ and [cmd/config/node1.yml](https://github.com/wind-c/comqtt/blob/main/cmd/config
 in the upstream repo. The chart's `config:` block mirrors those files
 verbatim.
 
-## Exposing MQTT externally
+## Exposing the broker externally
 
-A standard HTTP Ingress **cannot** proxy raw MQTT TCP — it is a Layer 7
-HTTP-only resource. Use one of:
+The chart prefers [Gateway API](https://gateway-api.sigs.k8s.io/) over the
+legacy `Ingress` resource. ingress-nginx is in [retirement as of
+2025-11-11](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/)
+and a Layer 7 Ingress cannot proxy raw MQTT in any case.
+
+### Gateway API (preferred)
+
+You bring the `Gateway` resource and a Gateway API provider. Examples:
+[Envoy Gateway](https://gateway.envoyproxy.io/), Cilium, Istio, Kong.
+
+The chart emits:
+
+- `HTTPRoute` for the dashboard (`gateway.dashboard.enabled`, default on)
+- `TCPRoute` for raw MQTT (`gateway.mqtt.enabled`, default off — TCPRoute is
+  in `gateway.networking.k8s.io/v1alpha2` and requires a TCP-aware provider)
+
+Minimal example with Envoy Gateway in front:
+
+```yaml
+# values.yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: eg
+      namespace: envoy-gateway-system
+  dashboard:
+    enabled: true
+    hostnames: ["comqtt.example.com"]
+  mqtt:
+    enabled: true
+```
+
+For TLS termination at the Gateway, configure listeners on the `Gateway`
+itself; for TLS at the broker, set `tls.existingSecret` and wire
+`config.mqtt.tls.{ca-cert,server-cert,server-key}`.
+
+### Legacy fallbacks
+
+If Gateway API is not available in your cluster:
 
 - `service.mqtt.type: LoadBalancer` — straightforward on cloud providers.
-- An Ingress controller with TCP passthrough (e.g. NGINX `--tcp-services-configmap`).
 - A NodePort plus an external load balancer or DNS round-robin.
-
-For TLS termination at the broker, supply `tls.existingSecret` and reference
-it from `config.mqtt.tls.{ca-cert,server-cert,server-key}`.
+- `ingress.*` (deprecated; dashboard only).
 
 ## Upgrades
 
@@ -183,8 +223,10 @@ it from `config.mqtt.tls.{ca-cert,server-cert,server-key}`.
 - No bundled RESP store. The chart expects an externally-deployed Redis or
   Valkey (see [ci/valkey.yaml](ci/valkey.yaml) for a starting point) — the
   chart does not manage failover or HA for it.
-- The dashboard Ingress proxies `/`. Mounting it under a sub-path is not
-  currently supported.
+- The dashboard `HTTPRoute` defaults to `PathPrefix /`. Override
+  `gateway.dashboard.matches` to mount under a sub-path; the dashboard's
+  embedded asset paths assume `/dashboard/`, so a sub-path mount needs an
+  HTTPRoute filter (`URLRewrite`) to strip the prefix before forwarding.
 
 ## Contributing
 

--- a/deploy/helm/comqtt/templates/NOTES.txt
+++ b/deploy/helm/comqtt/templates/NOTES.txt
@@ -36,7 +36,7 @@ To run the chart's bundled connectivity test:
 WARNING: `ingress.*` is DEPRECATED. ingress-nginx is in retirement
 (https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) and
 a Layer 7 Ingress cannot proxy raw MQTT. Migrate to `gateway.*`
-(Gateway API): set `gateway.enabled=true` plus `gateway.dashboard.enabled=true`
+(Gateway API): set `gateway.enabled=true` plus `gateway.api.enabled=true`
 (and `gateway.mqtt.enabled=true` for raw MQTT) and supply a Gateway via
 `gateway.parentRefs`.
 {{- end }}
@@ -44,11 +44,12 @@ a Layer 7 Ingress cannot proxy raw MQTT. Migrate to `gateway.*`
 {{- if .Values.gateway.enabled }}
 
 Gateway API routes:
-{{- if .Values.gateway.dashboard.enabled }}
-  HTTPRoute  {{ include "comqtt.fullname" . }}-dashboard  -> Service/{{ include "comqtt.fullname" . }}:{{ .Values.service.dashboard.port }}
+{{- if .Values.gateway.api.enabled }}
+  HTTPRoute  {{ include "comqtt.fullname" . }}-api  -> Service/{{ include "comqtt.fullname" . }}:{{ .Values.service.dashboard.port }}
+                                                       (REST API + /metrics)
 {{- end }}
 {{- if .Values.gateway.mqtt.enabled }}
-  TCPRoute   {{ include "comqtt.fullname" . }}-mqtt       -> Service/{{ include "comqtt.fullname" . }}:{{ .Values.service.mqtt.port }}
-                                                            (requires gateway.networking.k8s.io/v1alpha2)
+  TCPRoute   {{ include "comqtt.fullname" . }}-mqtt -> Service/{{ include "comqtt.fullname" . }}:{{ .Values.service.mqtt.port }}
+                                                       (requires gateway.networking.k8s.io/v1alpha2)
 {{- end }}
 {{- end }}

--- a/deploy/helm/comqtt/templates/NOTES.txt
+++ b/deploy/helm/comqtt/templates/NOTES.txt
@@ -33,7 +33,22 @@ To run the chart's bundled connectivity test:
 
 {{- if .Values.ingress.enabled }}
 
-Dashboard Ingress is enabled. Note: raw MQTT cannot be served by a Layer 7
-HTTP Ingress; for external MQTT use a LoadBalancer Service or an Ingress
-controller with TCP passthrough.
+WARNING: `ingress.*` is DEPRECATED. ingress-nginx is in retirement
+(https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) and
+a Layer 7 Ingress cannot proxy raw MQTT. Migrate to `gateway.*`
+(Gateway API): set `gateway.enabled=true` plus `gateway.dashboard.enabled=true`
+(and `gateway.mqtt.enabled=true` for raw MQTT) and supply a Gateway via
+`gateway.parentRefs`.
+{{- end }}
+
+{{- if .Values.gateway.enabled }}
+
+Gateway API routes:
+{{- if .Values.gateway.dashboard.enabled }}
+  HTTPRoute  {{ include "comqtt.fullname" . }}-dashboard  -> Service/{{ include "comqtt.fullname" . }}:{{ .Values.service.dashboard.port }}
+{{- end }}
+{{- if .Values.gateway.mqtt.enabled }}
+  TCPRoute   {{ include "comqtt.fullname" . }}-mqtt       -> Service/{{ include "comqtt.fullname" . }}:{{ .Values.service.mqtt.port }}
+                                                            (requires gateway.networking.k8s.io/v1alpha2)
+{{- end }}
 {{- end }}

--- a/deploy/helm/comqtt/templates/httproute.yaml
+++ b/deploy/helm/comqtt/templates/httproute.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.gateway.enabled .Values.gateway.dashboard.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "comqtt.fullname" . }}-dashboard
+  labels:
+    {{- include "comqtt.labels" . | nindent 4 }}
+  {{- with .Values.gateway.dashboard.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- $refs := .Values.gateway.dashboard.parentRefs }}
+    {{- if not $refs }}{{ $refs = .Values.gateway.parentRefs }}{{ end }}
+    {{- toYaml $refs | nindent 4 }}
+  {{- with .Values.gateway.dashboard.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.gateway.dashboard.matches | nindent 8 }}
+      backendRefs:
+        - name: {{ include "comqtt.fullname" . }}
+          port: {{ .Values.service.dashboard.port }}
+{{- end }}

--- a/deploy/helm/comqtt/templates/httproute.yaml
+++ b/deploy/helm/comqtt/templates/httproute.yaml
@@ -1,26 +1,33 @@
-{{- if and .Values.gateway.enabled .Values.gateway.dashboard.enabled -}}
+{{- if and .Values.gateway.enabled .Values.gateway.api.enabled -}}
+{{- /*
+HTTPRoute for the broker's HTTP listener (port 8080 by default), which
+serves the /api/v1/* REST surface and /metrics. The chart's
+`service.dashboard.port` value name is kept for back-compat with chart
+0.1.0; it refers to the HTTP listener port regardless of what is mounted
+on it.
+*/ -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ include "comqtt.fullname" . }}-dashboard
+  name: {{ include "comqtt.fullname" . }}-api
   labels:
     {{- include "comqtt.labels" . | nindent 4 }}
-  {{- with .Values.gateway.dashboard.annotations }}
+  {{- with .Values.gateway.api.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-    {{- $refs := .Values.gateway.dashboard.parentRefs }}
+    {{- $refs := .Values.gateway.api.parentRefs }}
     {{- if not $refs }}{{ $refs = .Values.gateway.parentRefs }}{{ end }}
     {{- toYaml $refs | nindent 4 }}
-  {{- with .Values.gateway.dashboard.hostnames }}
+  {{- with .Values.gateway.api.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
-        {{- toYaml .Values.gateway.dashboard.matches | nindent 8 }}
+        {{- toYaml .Values.gateway.api.matches | nindent 8 }}
       backendRefs:
         - name: {{ include "comqtt.fullname" . }}
           port: {{ .Values.service.dashboard.port }}

--- a/deploy/helm/comqtt/templates/tcproute.yaml
+++ b/deploy/helm/comqtt/templates/tcproute.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.gateway.enabled .Values.gateway.mqtt.enabled -}}
+{{- /*
+TCPRoute is in gateway.networking.k8s.io/v1alpha2 as of Gateway API v1.2 and
+ships only with TCP-aware Gateway implementations (Envoy Gateway, Cilium,
+etc.). Plain ingress-nginx does not support TCPRoute.
+*/ -}}
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: {{ include "comqtt.fullname" . }}-mqtt
+  labels:
+    {{- include "comqtt.labels" . | nindent 4 }}
+  {{- with .Values.gateway.mqtt.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- $refs := .Values.gateway.mqtt.parentRefs }}
+    {{- if not $refs }}{{ $refs = .Values.gateway.parentRefs }}{{ end }}
+    {{- toYaml $refs | nindent 4 }}
+  rules:
+    - backendRefs:
+        - name: {{ include "comqtt.fullname" . }}
+          port: {{ .Values.service.mqtt.port }}
+{{- end }}

--- a/deploy/helm/comqtt/values.schema.json
+++ b/deploy/helm/comqtt/values.schema.json
@@ -60,12 +60,23 @@
     },
     "ingress": {
       "type": "object",
+      "deprecated": true,
+      "description": "DEPRECATED. Prefer `gateway.*`.",
       "properties": {
         "enabled": { "type": "boolean" },
         "className": { "type": "string" },
         "annotations": { "type": "object" },
         "hosts": { "type": "array" },
         "tls": { "type": "array" }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "dashboard": { "$ref": "#/$defs/gatewayRoute" },
+        "mqtt": { "$ref": "#/$defs/gatewayRoute" }
       }
     },
     "tls": {
@@ -169,6 +180,16 @@
         },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "nodePort": { "type": ["integer", "string"] },
+        "annotations": { "type": "object" }
+      }
+    },
+    "gatewayRoute": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "matches": { "type": "array", "items": { "type": "object" } },
         "annotations": { "type": "object" }
       }
     }

--- a/deploy/helm/comqtt/values.schema.json
+++ b/deploy/helm/comqtt/values.schema.json
@@ -75,7 +75,7 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "parentRefs": { "type": "array", "items": { "type": "object" } },
-        "dashboard": { "$ref": "#/$defs/gatewayRoute" },
+        "api": { "$ref": "#/$defs/gatewayRoute" },
         "mqtt": { "$ref": "#/$defs/gatewayRoute" }
       }
     },

--- a/deploy/helm/comqtt/values.yaml
+++ b/deploy/helm/comqtt/values.yaml
@@ -127,9 +127,9 @@ ingress:
   #    back-compat only; ingress-nginx is in retirement
   #    (https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) and a
   #    standard HTTP Ingress cannot proxy raw MQTT TCP regardless. New
-  #    deployments should use `gateway.dashboard` (HTTPRoute) and
-  #    `gateway.mqtt` (TCPRoute) with a Gateway API provider such as Envoy
-  #    Gateway, Cilium, or Istio.
+  #    deployments should use `gateway.api` (HTTPRoute) and `gateway.mqtt`
+  #    (TCPRoute) with a Gateway API provider such as Envoy Gateway, Cilium,
+  #    or Istio.
   enabled: false
   className: ""
   annotations: {}
@@ -141,8 +141,9 @@ ingress:
   tls: []
 
 # Gateway API (preferred over `ingress:`). The chart emits an HTTPRoute for
-# the dashboard and a TCPRoute for raw MQTT. You bring the Gateway resource —
-# install one of the Gateway API providers (Envoy Gateway, Cilium, Istio,
+# the broker's HTTP listener (REST API at /api/v1/* and Prometheus metrics at
+# /metrics on port 8080) and a TCPRoute for raw MQTT. You bring the Gateway
+# resource: install a Gateway API provider (Envoy Gateway, Cilium, Istio,
 # Kong, etc.) and reference it from `parentRefs`. TCPRoute is alpha
 # (gateway.networking.k8s.io/v1alpha2) and supported by a subset of providers.
 gateway:
@@ -155,8 +156,9 @@ gateway:
   #    namespace: gateway-system
   #    sectionName: http        # for HTTPRoute
   #    sectionName: mqtt        # for TCPRoute
-  dashboard:
-    # -- Emit an HTTPRoute for the dashboard backend.
+  api:
+    # -- Emit an HTTPRoute for the broker's HTTP listener (REST API +
+    #    metrics on port 8080).
     enabled: true
     # -- Override `gateway.parentRefs` for this route. Empty inherits.
     parentRefs: []

--- a/deploy/helm/comqtt/values.yaml
+++ b/deploy/helm/comqtt/values.yaml
@@ -123,9 +123,13 @@ service:
     annotations: {}
 
 ingress:
-  # -- Enable Ingress for the dashboard. NOTE: a standard HTTP Ingress cannot
-  #    proxy raw MQTT TCP. To expose MQTT externally, use a LoadBalancer
-  #    Service or an Ingress controller with TCP/passthrough support.
+  # -- DEPRECATED. Prefer `gateway.*` (Gateway API). Ingress is retained for
+  #    back-compat only; ingress-nginx is in retirement
+  #    (https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) and a
+  #    standard HTTP Ingress cannot proxy raw MQTT TCP regardless. New
+  #    deployments should use `gateway.dashboard` (HTTPRoute) and
+  #    `gateway.mqtt` (TCPRoute) with a Gateway API provider such as Envoy
+  #    Gateway, Cilium, or Istio.
   enabled: false
   className: ""
   annotations: {}
@@ -135,6 +139,42 @@ ingress:
         - path: /
           pathType: Prefix
   tls: []
+
+# Gateway API (preferred over `ingress:`). The chart emits an HTTPRoute for
+# the dashboard and a TCPRoute for raw MQTT. You bring the Gateway resource —
+# install one of the Gateway API providers (Envoy Gateway, Cilium, Istio,
+# Kong, etc.) and reference it from `parentRefs`. TCPRoute is alpha
+# (gateway.networking.k8s.io/v1alpha2) and supported by a subset of providers.
+gateway:
+  # -- Master toggle. Routes also need their per-route `enabled` flag.
+  enabled: false
+  # -- Default `parentRefs` applied to both routes when the per-route value
+  #    is empty. Each entry is a Gateway API ParentReference object.
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: http        # for HTTPRoute
+  #    sectionName: mqtt        # for TCPRoute
+  dashboard:
+    # -- Emit an HTTPRoute for the dashboard backend.
+    enabled: true
+    # -- Override `gateway.parentRefs` for this route. Empty inherits.
+    parentRefs: []
+    # -- Hostnames the route matches (HTTPRoute `spec.hostnames`).
+    hostnames: []
+    # -- HTTPRoute path matches. Defaults to PathPrefix `/`.
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    annotations: {}
+  mqtt:
+    # -- Emit a TCPRoute for raw MQTT. Requires a Gateway implementation
+    #    that supports gateway.networking.k8s.io/v1alpha2 TCPRoute.
+    enabled: false
+    # -- Override `gateway.parentRefs` for this route.
+    parentRefs: []
+    annotations: {}
 
 tls:
   # -- Enable MQTT TLS. When enabled either provide `existingSecret` or wire


### PR DESCRIPTION
Adds Gateway API resources to the chart and marks the Ingress block as deprecated, per @sansmoraxz's [review feedback on #150](https://github.com/wind-c/comqtt/pull/150#issuecomment-4386812972) about [ingress-nginx retirement](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/).

## What's in

### New resources

| File | apiVersion | Purpose |
|---|---|---|
| `templates/httproute.yaml` | `gateway.networking.k8s.io/v1` | Routes the dashboard to a user-supplied Gateway. |
| `templates/tcproute.yaml` | `gateway.networking.k8s.io/v1alpha2` | Routes raw MQTT TCP. Requires a TCP-aware Gateway provider (Envoy Gateway, Cilium, etc.). |

### New `gateway:` values block

```yaml
gateway:
  enabled: false
  parentRefs:                  # default for both routes
    - name: my-gateway
      namespace: gateway-system
  dashboard:
    enabled: true
    parentRefs: []             # override gateway.parentRefs
    hostnames: []
    matches:
      - path: { type: PathPrefix, value: / }
  mqtt:
    enabled: false
    parentRefs: []
```

Per-route `parentRefs` falls back to `gateway.parentRefs` when empty, so the common case is one `parentRefs:` entry on the chart-level block.

### Ingress deprecation

- `values.yaml` comment marks the block DEPRECATED with the upstream retirement reference.
- `values.schema.json` flags the property `deprecated: true`.
- `NOTES.txt` prints a migration warning when `ingress.enabled=true`.
- README replaces the "Exposing MQTT externally" section with a Gateway-API-first guide; legacy Ingress is kept as a documented fallback.

The existing `templates/ingress.yaml` is **retained for back-compat** so existing users aren't broken on upgrade. Removal can land in a future major chart bump.

## Verification (`helm template ci .`)

| Path | Result |
|---|---|
| `gateway.enabled=true`, both routes + `ingress.enabled=true` | HTTPRoute (`gateway.networking.k8s.io/v1`) + TCPRoute (`gateway.networking.k8s.io/v1alpha2`) + Ingress all rendered; deprecation warning fires in NOTES |
| `gateway.dashboard.enabled=false`, `gateway.mqtt.enabled=true` | TCPRoute only |
| Default values | No gateway resources rendered (master toggle off) |

`helm lint .` clean.

## Out of scope

- Removing the legacy `templates/ingress.yaml`. Defer to a future major bump (e.g. chart `1.0.0`) when enough time has passed for users to migrate.
- A `Gateway` resource. Convention is for the chart to ship Routes; users supply the Gateway via `parentRefs`. Bundling a Gateway would couple the chart to one provider.
- TLS configuration on the Routes themselves. For TLS at the Gateway, configure the `Gateway` listener; for TLS at the broker, the existing `tls.*` values still apply.

## Refs

- Gateway API: https://gateway-api.sigs.k8s.io/
- TCPRoute guide: https://gateway-api.sigs.k8s.io/guides/tcp/
- Envoy Gateway (suggested provider): https://gateway.envoyproxy.io/