### PR TITLE
fix: prevent concurrent map r/w in KV.GetAll during raft snapshot

### DIFF
--- a/cluster/raft/base.go
+++ b/cluster/raft/base.go
@@ -37,7 +37,11 @@ func NewKV() *KV {
 func (k *KV) GetAll() *data {
 	k.RLock()
 	defer k.RUnlock()
-	return &k.data
+	cp := make(data, len(k.data))
+	for k, v := range k.data {
+		cp[k] = append([]string(nil), v...)
+	}
+	return &cp
 }
 
 func (k *KV) Get(key string) []string {


### PR DESCRIPTION
Fixes #126.

## Problem

`Fsm.Persist()` calls `gob.Encode(f.GetAll())` to encode the cluster subscription map into a raft snapshot. `GetAll()` acquires `RLock`, returns a raw `*data` pointer, then releases the lock. `gob.Encode` subsequently iterates the map while other goroutines (`Apply() -> Add()/Del()`) can concurrently write it, causing:

```
fatal error: concurrent map iteration and map write
```

## Fix

Replace the raw pointer return in `GetAll()` with a deep copy performed inside the `RLock` critical section. Callers receive an independent snapshot of the map, safe from concurrent mutations.

## Verification

```bash
go vet ./cluster/raft/...
go test -race -count=1 ./cluster/raft/hashicorp/...
```