### PR TITLE
fix: prevent session takeover loop on client reconnect

### DIFF
--- a/mqtt/server.go
+++ b/mqtt/server.go
@@ -494,6 +494,7 @@ func (s *Server) validateConnect(cl *Client, pk packets.Packet) packets.Code {
 func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
 	if existing, ok := s.Clients.Get(pk.Connect.ClientIdentifier); ok {
 		_ = s.DisconnectClient(existing, packets.ErrSessionTakenOver)                                   // [MQTT-3.1.4-3]
+		s.Clients.Delete(existing.ID)                                                                    // prevent race: remove old entry before adding new one
 		if pk.Connect.Clean || (existing.Properties.Clean && existing.Properties.ProtocolVersion < 5) { // [MQTT-3.1.2-4] [MQTT-3.1.4-4]
 			s.UnsubscribeClient(existing)
 			existing.ClearInflights(math.MaxInt64, 0)


### PR DESCRIPTION
## Problem

When a client reconnects with the same ClientID and `Clean=false`, `inheritClientSession` finds the old entry in `s.Clients`, sends `ErrSessionTakenOver`, but the old entry is only removed asynchronously by the read loop defer path. If the client reconnects again before that cleanup runs, it hits the same stale entry — triggering another takeover in an infinite loop.

```
Client reconnects → inheritClientSession finds old entry → DisconnectClient → Stop() async → Client reconnects → old entry still there → repeat
```

## Fix

Synchronously delete the old client from `s.Clients` right after `DisconnectClient`:

```go
_ = s.DisconnectClient(existing, packets.ErrSessionTakenOver)
s.Clients.Delete(existing.ID)  // remove old entry immediately
```

This eliminates the race window where a fast-reconnecting client could trigger repeated takeovers.

## Verification

```bash
go vet ./mqtt/...
go test -run "TestInheritClient|TestEstablish" ./mqtt/ -count=1
```

All 10 related tests pass.