### PR TITLE
feat(server): add Server.Hooks() accessor for external hook authors

### DIFF
--- a/mqtt/server.go
+++ b/mqtt/server.go
@@ -249,6 +249,13 @@ func (s *Server) NewClient(c net.Conn, listener string, id string, inline bool) 
 	return cl
 }
 
+// Hooks returns the registered hook bus. External hook authors and
+// monitoring tools may need to read state stored by hooks (e.g. the
+// session storage chain) without reaching into unexported fields.
+func (s *Server) Hooks() *Hooks {
+	return s.hooks
+}
+
 // AddHook attaches a new Hook to the server. Ideally, this should be called
 // before the server is started with s.Serve().
 func (s *Server) AddHook(hook Hook, config any) error {


### PR DESCRIPTION
Adds a small read-only accessor to `*mqtt.Server`:

```go
func (s *Server) Hooks() *Hooks {
    return s.hooks
}
```

## Rationale

External hook authors and monitoring tooling sometimes need to read state that hooks themselves store. The session storage chain is the concrete motivating case: a hook implementing `StoredClients`, `StoredSubscriptions`, `StoredRetainedMessages`, etc. is the source of truth for offline session inspection, and there is currently no in-tree way to reach the hook bus to query it without unsafe access to unexported fields.

The accessor is a getter for an existing pointer, not new behavior. Hooks already mutate state through `s.hooks` internally; this just exposes a read-only path for code outside the package.

## Scope

- 7 lines (5 of code, 3 of doc comment).
- No behavior change.
- No new dependencies.
- Public API addition only; no rename or break.

## Context

Split out from #151 per maintainer feedback that the dashboard PR was too large to evaluate. The dashboard work itself will move to a separate add-on module (`debsahu/comqtt-dashboard`) so comqtt remains focused on the broker. This accessor is the only upstream change that work needs from comqtt.