### PR TITLE
feat(cluster): add Agent.Leader() accessor

### DIFF
--- a/cluster/agent.go
+++ b/cluster/agent.go
@@ -201,6 +201,18 @@ func (a *Agent) GetMemberList() []discovery.Member {
 	return a.membership.Members()
 }
 
+// Leader returns the node id of the current Raft leader, or "" if no leader
+// is elected (e.g. mid-election or before the cluster has converged).
+//
+// Exposed for monitoring tooling and external hook authors that need to
+// render cluster topology - the dashboard's cluster page in particular.
+// Trivial wrapper over raftPeer.GetLeader(), which is otherwise unreachable
+// from outside this package.
+func (a *Agent) Leader() string {
+	_, id := a.raftPeer.GetLeader()
+	return id
+}
+
 func getRaftPeerAddr(member *discovery.Member) string {
 	// using serf
 	if raftPort, ok := member.Tags[discovery.TagRaftPort]; ok {


### PR DESCRIPTION
## Summary

Adds a small read-only accessor to `*cluster.Agent`:

```go
func (a *Agent) Leader() string {
    _, id := a.raftPeer.GetLeader()
    return id
}
```

## Rationale

External monitoring tools and observability dashboards need to render which cluster node currently holds the Raft leadership. The information is already tracked by `a.raftPeer.GetLeader()`, but `raftPeer` is unexported, so there is no in-tree way for callers outside the `cluster` package to read leader state without unsafe access to unexported fields.

The accessor follows the same pattern as the `Server.Hooks()` accessor merged in #158: a small wrapper that exposes existing state to observers, with no behavior change inside the package.

## Scope

* 12 lines (4 of code, 8 of doc comment).
* No behavior change inside the cluster runtime.
* No new dependencies.
* Public API addition only. No rename or break.
* Returns `""` when no leader is elected (mid-election, pre-bootstrap), which is the sentinel `raftPeer.GetLeader()` already returns in those cases.

## Context

Needed by the `debsahu/comqtt-dashboard` add-on, which renders cluster topology and a leader badge on its Cluster page. The add-on was split out of #151 per maintainer feedback that the original PR was too large to evaluate; it now lives as a separate Go module so comqtt itself stays focused on the broker. This accessor is the only upstream change the dashboard's cluster-mode binary needs beyond #158.