### PR TITLE
fix: add OCI chart publish and clarify Helm repo availability

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -11,6 +11,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  packages: write
 
 jobs:
   release:
@@ -38,3 +39,12 @@ jobs:
           charts_dir: deploy/helm
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Push chart to GHCR (OCI)
+        run: |
+          CHART_VERSION=$(yq '.version' deploy/helm/comqtt/Chart.yaml)
+          helm package deploy/helm/comqtt --destination /tmp
+          helm push /tmp/comqtt-${CHART_VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -45,6 +45,6 @@ jobs:
 
       - name: Push chart to GHCR (OCI)
         run: |
-          CHART_VERSION=$(yq '.version' deploy/helm/comqtt/Chart.yaml)
+          CHART_VERSION=$(helm show chart deploy/helm/comqtt | grep '^version:' | awk '{print $2}')
           helm package deploy/helm/comqtt --destination /tmp
           helm push /tmp/comqtt-${CHART_VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/README.md
+++ b/README.md
@@ -116,7 +116,13 @@ helm install cluster deploy/helm/comqtt \
   -f deploy/helm/comqtt/ci/cluster-values.yaml
 ```
 
-Released charts are also available from the GitHub Pages-hosted Helm repository published by the `chart-release` workflow.
+Released charts are available as OCI artifacts on GHCR (recommended):
+
+```sh
+helm install my-broker oci://ghcr.io/wind-c/charts/comqtt
+```
+
+They are also published to a GitHub Pages-hosted Helm repository by the `chart-release` workflow, but this requires GitHub Pages to be enabled in the repository settings. If `helm repo add` returns a 404, use the OCI method above instead.
 
 ## Developing with Comqtt
 ### Importing as a package

--- a/deploy/helm/comqtt/Chart.yaml
+++ b/deploy/helm/comqtt/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   comqtt — a lightweight, high-performance MQTT broker (v3.0/v3.1.1/v5.0)
   supporting standalone and clustered (Raft + Gossip) deployments.
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "2.6.0"
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/wind-c/comqtt
@@ -24,6 +24,8 @@ maintainers:
 icon: https://raw.githubusercontent.com/wind-c/comqtt/main/README.md
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: OCI chart publishing to GHCR (oci://ghcr.io/wind-c/charts/comqtt).
     - kind: added
       description: Gateway API support, HTTPRoute (REST API + /metrics) and TCPRoute (MQTT).
     - kind: deprecated

--- a/deploy/helm/comqtt/README.md
+++ b/deploy/helm/comqtt/README.md
@@ -9,6 +9,32 @@ Resolves [issue #137](https://github.com/wind-c/comqtt/issues/137).
 ## TL;DR
 
 ```bash
+helm install my-broker oci://ghcr.io/wind-c/charts/comqtt
+```
+
+## Install
+
+### OCI (recommended)
+
+Charts are published to GHCR as OCI artifacts alongside the Docker images:
+
+```bash
+helm install my-broker oci://ghcr.io/wind-c/charts/comqtt
+```
+
+To install a specific version:
+
+```bash
+helm install my-broker oci://ghcr.io/wind-c/charts/comqtt --version 0.3.0
+```
+
+### Helm repository
+
+> **Note:** The HTTP Helm repository at `https://wind-c.github.io/comqtt` requires
+> GitHub Pages to be enabled in the repository settings. If you see a 404, the
+> repo admin hasn't enabled it yet — use the OCI method above instead.
+
+```bash
 helm repo add comqtt https://wind-c.github.io/comqtt
 helm install my-broker comqtt/comqtt
 ```

--- a/deploy/helm/comqtt/README.md
+++ b/deploy/helm/comqtt/README.md
@@ -25,7 +25,7 @@ helm install my-broker oci://ghcr.io/wind-c/charts/comqtt
 To install a specific version:
 
 ```bash
-helm install my-broker oci://ghcr.io/wind-c/charts/comqtt --version 0.3.0
+helm install my-broker oci://ghcr.io/wind-c/charts/comqtt --version 0.4.0
 ```
 
 ### Helm repository


### PR DESCRIPTION
## Summary

Fixes #161 — Helm chart not actually published to GitHub Pages despite README claim.

The chart README and main README both pointed users to `helm repo add comqtt https://wind-c.github.io/comqtt`, but this URL returns 404 because GitHub Pages isn't enabled on the repo. The `helm/chart-releaser-action` pushes a `gh-pages` branch, but Pages itself must be manually enabled in repo settings — something no workflow token can automate.

## Changes

### `.github/workflows/chart-release.yaml`
- Added `packages: write` permission (required for GHCR OCI push)
- Added **Login to GHCR** step and **Push chart to GHCR (OCI)** step after `chart-releaser`
- Charts are now published to `oci://ghcr.io/wind-c/charts/comqtt` automatically alongside the existing GitHub Pages flow — no manual repo settings required

### `deploy/helm/comqtt/README.md`
- TL;DR now shows `helm install my-broker oci://ghcr.io/wind-c/charts/comqtt` (the working method)
- Added "Install" section: OCI (recommended) primary, Helm repo as fallback
- Added note that HTTP Helm repo requires GitHub Pages to be enabled by the repo admin

### `README.md`
- Replaced the misleading "Released charts are also available from the GitHub Pages-hosted Helm repository" with:
  - OCI install command (recommended, works automatically)
  - Clarification that the HTTP Helm repo needs GitHub Pages enabled, with 404 guidance

## Remaining manual step

For the HTTP Helm repo (`https://wind-c.github.io/comqtt`) to also work, a repo admin needs to enable GitHub Pages in Settings → Pages → Source: "GitHub Actions". The `chart-releaser-action` will handle the rest on the next push to `deploy/helm/**`. OCI works immediately without this step.