### PR TITLE
fix: prevent panic on SUBSCRIBE v5 with empty filter (DoS CVE)

### DIFF
--- a/mqtt/packets/packets.go
+++ b/mqtt/packets/packets.go
@@ -965,10 +965,13 @@ func (pk *Packet) SubscribeDecode(buf []byte) error {
 		}
 
 		if pk.ProtocolVersion == 5 {
-			if err := sub.decode(buf[offset]); err != nil {
+			option, offset, err = decodeByte(buf, offset)
+			if err != nil {
+				return ErrMalformedQos
+			}
+			if err := sub.decode(option); err != nil {
 				return err
 			}
-			offset += 1
 		} else {
 			option, offset, err = decodeByte(buf, offset)
 			if err != nil {

--- a/mqtt/packets/tpackets.go
+++ b/mqtt/packets/tpackets.go
@@ -215,6 +215,7 @@ const (
 	TAuthInvalidReason
 	TAuthInvalidReason2
 	TSubscribeMalformedReservedBits
+	TSubscribeMalformedNoOption
 )
 
 // TPacketData contains individual encoding and decoding scenarios for each packet type.
@@ -3122,6 +3123,21 @@ var TPacketData = map[byte]TPacketCases{
 				0x00, 0x05, // Topic filter length = 5
 				'a', '/', 'b', '/', 'c', // Topic filter
 				0xC0, // Option byte (bits 6-7 = 11, reserved non-zero)
+			},
+			Packet: &Packet{
+				ProtocolVersion: 5,
+			},
+		},
+		{
+			Case:      TSubscribeMalformedNoOption,
+			Desc:      "malformed subscribe v5 - no option byte after empty filter",
+			Group:     "decode",
+			FailFirst: ErrMalformedQos,
+			RawBytes: []byte{
+				Subscribe<<4 | 1<<1, 5, // Fixed header
+				0x00, 0x01, // Packet ID = 1
+				0x00,       // Properties length = 0
+				0x00, 0x00, // Topic filter length = 0 (empty filter)
 			},
 			Packet: &Packet{
 				ProtocolVersion: 5,


### PR DESCRIPTION
## Summary

Fixes a DoS vulnerability (CVSS 3.1 7.5) reported by Team Atlanta. A remote attacker can crash the broker with a single 7-byte crafted SUBSCRIBE packet.

## Root Cause

In \mqtt/packets/packets.go:968\, the MQTT v5 SUBSCRIBE path dereferences \uf[offset]\ without bounds checking. When the topic filter is empty (length 0x00 0x00), \decodeString\ advances offset to \len(buf)\, and the subsequent raw byte access triggers an unrecovered Go runtime panic, killing the entire broker process.

The v3 path at line 976 already uses the safe \decodeByte\ helper which returns \ErrMalformedOffsetByteOutOfRange\ on underflow.

## Fix

Replace \sub.decode(buf[offset]); offset += 1\ with \decodeByte(buf, offset)\ + error check, mirroring the v3 path.

## Test

Added \TSubscribeMalformedNoOption\ regression test with the exact PoC payload.

## Changes

\\\
mqtt/packets/packets.go  | 6 ++++--
mqtt/packets/tpackets.go | 17 ++++++++++++++++-
\\\

/cc @wind-c