### PR TITLE
fix: ACL bypass via prefix topic matching (CVSS 4.3)

### DIFF
--- a/mqtt/hooks/auth/ledger.go
+++ b/mqtt/hooks/auth/ledger.go
@@ -159,7 +159,7 @@ func MatchTopic(filter string, topic string) (elements []string, matched bool) {
 		}
 	}
 
-	return elements, true
+	return elements, len(topicParts) == len(filterParts)
 }
 
 // Ledger is an auth ledger containing access rules for users and topics.

--- a/mqtt/hooks/auth/ledger_test.go
+++ b/mqtt/hooks/auth/ledger_test.go
@@ -492,6 +492,14 @@ func TestMatchTopic(t *testing.T) {
 	el, matched = MatchTopic(" ", "  ")
 	require.False(t, matched)
 	require.Equal(t, make([]string, 0), el)
+
+	el, matched = MatchTopic("test", "test/child")
+	require.False(t, matched)
+	require.Equal(t, make([]string, 0), el)
+
+	el, matched = MatchTopic("a/+/c/+", "a/b/c/d/e")
+	require.False(t, matched)
+	require.Equal(t, []string{"b", "d"}, el)
 }
 
 var (


### PR DESCRIPTION
Fixes an ACL bypass vulnerability (CVSS 3.1 4.3) reported by Team Atlanta. A literal write ACL like 'allowed' was treated as matching a publish to 'allowed/secret', allowing low-privilege clients to publish to protected child topics.

Root cause: MatchTopic at ledger.go:162 returns true unconditionally after exhausting filter parts, without checking whether topic parts remain.

Fix: return elements, len(topicParts) == len(filterParts). The '#' multi-level wildcard path is unaffected (returns early).

/cc @wind-c