### PR TITLE
fix: ACL bypass and # wildcard zero-children in MatchTopic

### DIFF
--- a/mqtt/hooks/auth/ledger.go
+++ b/mqtt/hooks/auth/ledger.go
@@ -159,7 +159,7 @@ func MatchTopic(filter string, topic string) (elements []string, matched bool) {
 		}
 	}
 
-	return elements, true
+	return elements, len(topicParts) == len(filterParts)
 }
 
 // Ledger is an auth ledger containing access rules for users and topics.

--- a/mqtt/hooks/auth/ledger.go
+++ b/mqtt/hooks/auth/ledger.go
@@ -138,7 +138,7 @@ func MatchTopic(filter string, topic string) (elements []string, matched bool) {
 	elements = make([]string, 0)
 	for i := 0; i < len(filterParts); i++ {
 		if i >= len(topicParts) {
-			matched = false
+			matched = filterParts[i] == "#"
 			return
 		}
 

--- a/mqtt/hooks/auth/ledger_test.go
+++ b/mqtt/hooks/auth/ledger_test.go
@@ -492,6 +492,14 @@ func TestMatchTopic(t *testing.T) {
 	el, matched = MatchTopic(" ", "  ")
 	require.False(t, matched)
 	require.Equal(t, make([]string, 0), el)
+
+	el, matched = MatchTopic("test", "test/child")
+	require.False(t, matched)
+	require.Equal(t, make([]string, 0), el)
+
+	el, matched = MatchTopic("a/+/c/+", "a/b/c/d/e")
+	require.False(t, matched)
+	require.Equal(t, []string{"b", "d"}, el)
 }
 
 var (

--- a/mqtt/hooks/auth/ledger_test.go
+++ b/mqtt/hooks/auth/ledger_test.go
@@ -303,7 +303,7 @@ func TestCanACL(t *testing.T) {
 			ok:    false,
 		},
 		{
-			desc: "allow read on not-acl path (no #)",
+			desc: "deny read on write-only path base (fix # wildcard zero-children)",
 			client: &mqtt.Client{
 				Properties: mqtt.ClientProperties{
 					Username: []byte("mochi"),
@@ -311,7 +311,8 @@ func TestCanACL(t *testing.T) {
 			},
 			topic: "updates",
 			write: false,
-			ok:    true,
+			n:    0,
+			ok:   false,
 		},
 		{
 			desc: "allow write on write-only path",
@@ -500,6 +501,14 @@ func TestMatchTopic(t *testing.T) {
 	el, matched = MatchTopic("a/+/c/+", "a/b/c/d/e")
 	require.False(t, matched)
 	require.Equal(t, []string{"b", "d"}, el)
+
+	el, matched = MatchTopic("a/#", "a")
+	require.True(t, matched)
+	require.Equal(t, []string{}, el)
+
+	el, matched = MatchTopic("a/+", "a")
+	require.False(t, matched)
+	require.Equal(t, make([]string, 0), el)
 }
 
 var (


### PR DESCRIPTION
#170 - MatchTopic fixes

## Fix 1: ACL bypass via prefix topic matching (CVSS 4.3)

Reported by Team Atlanta. MatchTopic returned true unconditionally after exhausting filter parts, without checking whether topic parts remain. A literal filter "allowed" matched publish to "allowed/secret".
Fix: return len(topicParts) == len(filterParts)

## Fix 2: # wildcard zero-children matching

Per MQTT 4.7 spec, # must match zero or more child levels. The bounds check returned false before checking if filter part was #, so a/# failed to match a.
Fix: matched = filterParts[i] == "#"

## Changes
mqtt/hooks/auth/ledger.go      2+
mqtt/hooks/auth/ledger_test.go 16+

Reported by Team Atlanta.
